### PR TITLE
Move declaration of user constraints to make visible for simulink

### DIFF
--- a/userfctR/user_load.c
+++ b/userfctR/user_load.c
@@ -1,0 +1,31 @@
+/** ---------------------------
+  * Robotran - MBsysC
+  * 
+  * Template file for equilibrium module
+  * 
+  * This files enable the user to call custom code just 
+  * after loading the project. 
+  * The call is done inside the mbs_load function.
+  * 
+  * (c) Universite catholique de Louvain
+  *     
+  */
+
+#include "math.h"
+
+#include "mbs_data.h"
+
+#include "mbs_set.h"
+
+/*! \brief user own initialization functions
+ *
+ * \param[in,out] mbs_data data structure of the model
+ *
+ */
+void user_load_post(MbsData *mbs_data)
+{
+	
+    // Set the number of user constraints
+    int N_usr_c = 5;
+    mbs_set_nb_userc(mbs_data, N_usr_c);	
+}

--- a/workR/src/main.c
+++ b/workR/src/main.c
@@ -49,9 +49,7 @@ int main(int argc, char const *argv[])
     mbs_data = mbs_load(PROJECT_SOURCE_DIR"/../dataR/Frank_segway.mbs", BUILD_PATH);
     printf("*.mbs file loaded!\n");
     
-    // Set the number of user constraints
-    int N_usr_c = 5;
-    mbs_set_nb_userc(mbs_data, N_usr_c);
+
 
     /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
     /*              COORDINATE PARTITIONING                      *


### PR DESCRIPTION
This modification should solve the problem of running the model with user constraints in simulink.

The basic idea is that simulink does not use the main.c file. So, setting the number of constraints in main.c is taken into account for the standalone executable but not for the s-function. To solve that, we recently add a new user_load.c file with the user_load_post that is called at the end of the mbs file loading. I move the code to this function to ensure it is called by the s-function also.

I will add this info to the doc because it is not documented yet.